### PR TITLE
feat: hover and press interactions for floating images

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -109,9 +109,22 @@ import {ThemeToggle} from '../components/ThemeToggle';
     opacity: 0;
     background-size: cover;
     background-position: center;
+    pointer-events: auto;
+    cursor: pointer;
+    transition: transform 0.5s var(--ease-elastic-out-3);
     animation:
       drift-in 1.2s var(--ease-2) var(--delay) forwards,
       float var(--float-dur, 7s) var(--ease-2) var(--delay) infinite;
+  }
+
+  .float-img:hover {
+    transform: scale(1.15);
+  }
+
+  .float-img:active {
+    transform: scale(0.9);
+    transition-duration: 0.15s;
+    transition-timing-function: var(--ease-bounce-3);
   }
 
   .img-1 {
@@ -287,6 +300,7 @@ import {ThemeToggle} from '../components/ThemeToggle';
 
     .float-img {
       opacity: 0.08;
+      transition: none;
     }
 
     .name {


### PR DESCRIPTION
## Summary
- Hovering floating images scales them up (1.15x) with elastic easing via `--ease-elastic-out-3`
- Clicking/tapping squeezes to 0.9x with `--ease-bounce-3`, springs back on release
- Pointer events enabled on individual images while container stays inert (text remains selectable)
- Respects `prefers-reduced-motion` (disables transitions)

## Test plan
- [ ] Hover over each floating image — confirms elastic scale-up
- [ ] Click/tap images — confirms squeeze + bounce-back on release
- [ ] Verify text behind images is still selectable
- [ ] Enable `prefers-reduced-motion` — no hover/press effects